### PR TITLE
Add new line before "Closes...." line

### DIFF
--- a/lib/Gentoo/App/Pram.pm
+++ b/lib/Gentoo/App/Pram.pm
@@ -114,7 +114,7 @@ sub add_closes_header {
     print qq#Adding "Closes:" header ... #;
     my $confirm = E_NO;
     
-    my $header = "Closes: $close_url\n---";
+    my $header = "\nCloses: $close_url\n---";
     my @patch = ();
     
     for (split /\n/, $patch) {


### PR DESCRIPTION
Looks nicer seperated in commit message

Signed-off-by: Justin Lecher <jlec@gentoo.org>